### PR TITLE
us 3.1.1 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "us" %}
-{% set version = "2.0.2" %}
+{% set version = "3.1.1" %}
 {% set bundle = "tar.gz" %}
-{% set hash = "cb11ad0d43deff3a1c3690c74f0c731cff5b862c73339df2edd91133e1496fbc" %}
+{% set hash = "e347963e8d24a1ca7437af443fa68591776847b50c8650d8ef0eb53482e705c2" %}
 {% set build = 0 %}
 
 package:
@@ -12,31 +12,35 @@ source:
   fn: {{ name }}-{{ version }}.{{ bundle }}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
   sha256: {{ hash }}
+  patches:
+    - patches/0001-loosen-jellyfish-ties.patch
 
 build:
-  noarch: python
+  skip: True  # [py<36]
   entry_points:
     - states = us.cli.states:main
   number: {{ build }}
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
     - setuptools
+    - wheel
   run:
-    - python >=3.6
-    - jellyfish ==0.5.6
-    - setuptools
+    - python
+    - jellyfish # ==0.11.2
 
 test:
   imports:
     - us
     - us.cli
-
+  requires:
+    - pip
   commands:
     - states --help
+    - pip check
 
 about:
   home: https://github.com/unitedstates/python-us

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,6 @@ requirements:
     - jellyfish >=0.11.2
 
 test:
-  source_files:
-    - us/tests
   imports:
     - us
     - us.cli
@@ -49,7 +47,7 @@ test:
   commands:
     - states --help
     - pip check
-    - pytest -v us/tests
+    - pytest -v --pyargs us
 
 about:
   home: https://github.com/unitedstates/python-us

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,13 +16,17 @@ source:
     - patches/0001-loosen-jellyfish-ties.patch
 
 build:
-  skip: True  # [py<36]
+  # no jellyfish>=0.11.2 on s390x
+  skip: True  # [py<36 or s390x]
   entry_points:
     - states = us.cli.states:main
   number: {{ build }}
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
+  build:
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
     - pip
     - python
@@ -30,17 +34,22 @@ requirements:
     - wheel
   run:
     - python
-    - jellyfish # ==0.11.2
+    - jellyfish >=0.11.2
 
 test:
+  source_files:
+    - us/tests
   imports:
     - us
     - us.cli
   requires:
     - pip
+    - pytest
+    - pytz
   commands:
     - states --help
     - pip check
+    - pytest -v us/tests
 
 about:
   home: https://github.com/unitedstates/python-us
@@ -48,7 +57,10 @@ about:
   license_file: LICENSE
   license_family: BSD
   summary: US state meta information and other fun stuff
+  description: |
+    A package for easily working with US and state metadata.
   dev_url: https://github.com/unitedstates/python-us
+  doc_url: https://pypi.org/project/us/
 
 extra:
   recipe-maintainers:

--- a/recipe/patches/0001-loosen-jellyfish-ties.patch
+++ b/recipe/patches/0001-loosen-jellyfish-ties.patch
@@ -1,0 +1,25 @@
+From 3fb38714b59b0f46a9e31c4b9bdcebb93f4873e6 Mon Sep 17 00:00:00 2001
+From: Ian Fitchet <ifitchet@anaconda.com>
+Date: Thu, 4 Jul 2024 15:57:30 +0100
+Subject: [PATCH] loosen jellyfish ties
+
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 0566674..87e049b 100644
+--- a/setup.py
++++ b/setup.py
+@@ -13,7 +13,7 @@ setup(
+     license="BSD",
+     packages=find_packages(),
+     include_package_data=True,
+-    install_requires=["jellyfish==0.11.2"],
++    install_requires=["jellyfish>=0.11.2"],
+     entry_points={"console_scripts": ["states = us.cli.states:main"]},
+     platforms=["any"],
+     classifiers=[
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
us 3.1.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5099]
- dev_url:        https://github.com/unitedstates/python-us/tree/34da8f6ff7d694014b47b60ca189332f28431c68
- conda_forge:    https://github.com/conda-forge/us-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/us/3.1.1
- pypi inspector: https://inspector.pypi.io/project/us/3.1.1

### Explanation of changes:

- basic build
  - patch to loosen `jellyfish` ties to `>=0.11.2`
- rework test invocation for bundled tests


[PKG-5099]: https://anaconda.atlassian.net/browse/PKG-5099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ